### PR TITLE
Manage Tags

### DIFF
--- a/src/components/posts/ManagePostTags.js
+++ b/src/components/posts/ManagePostTags.js
@@ -64,7 +64,6 @@ export const ManagePostTags = ({ token, postId, currentPost, originalTagsOnPost,
 
     const addOrRemoveTag = (e) => {
         const checkedTagId = parseInt(e.target.value)
-        console.log("checkedTagId", checkedTagId)
         if (tagsOnPost.includes(checkedTagId)) {
             const updatedTags = tagsOnPost.filter(tagId => tagId !== checkedTagId)
             updateTagsOnPost(updatedTags)

--- a/src/components/posts/ManagePostTags.js
+++ b/src/components/posts/ManagePostTags.js
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getTags } from "../../managers/TagManager";
+
+
+export const ManagePostTags = ({ token, postId, currentPost, originalTagsOnPost, updateEditTags, fetchPostDetails  }) => {
+
+    // Default state for all tags to list on form
+    const [tagList, setTagList] = useState([])
+    // Track state for tags being added to post
+    const [tagsOnPost, updateTagsOnPost] = useState([])
+    const [postTagsFetched, updatePostTagsFetched] = useState(false)
+
+
+    const [post, update] = useState({
+        author_id: currentPost.author.id,
+        category_id: currentPost.category.id,
+        title: currentPost.title,
+        image_url: currentPost.image_url,
+        content: currentPost.content
+    });
+
+    useEffect(
+        () => {
+            getTags(token)
+                .then(tagData => setTagList(tagData))
+            if (!postTagsFetched) {
+                const arrayOfTagIds = originalTagsOnPost.map(t => t.id)
+                updateTagsOnPost(arrayOfTagIds)
+                updatePostTagsFetched(true)
+            }
+        },
+        []
+    )
+
+    const navigate = useNavigate();
+
+    const handleSaveButtonClick = (event) => {
+        event.preventDefault();
+
+        const postBody = {
+            author: post.author_id,
+            category: post.category_id,
+            title: post.title,
+            image_url: post.image_url,
+            content: post.content,
+            tags: tagsOnPost
+        };
+
+        fetch(`http://localhost:8000/posts/${postId}`, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Token ${token}`
+            },
+            body: JSON.stringify(postBody)
+        })
+            .then(() => {
+                updateEditTags(false)
+                fetchPostDetails()
+                navigate(`/posts/${postId}`)
+            });
+    };
+
+    const addOrRemoveTag = (e) => {
+        const checkedTagId = parseInt(e.target.value)
+        console.log("checkedTagId", checkedTagId)
+        if (tagsOnPost.includes(checkedTagId)) {
+            const updatedTags = tagsOnPost.filter(tagId => tagId !== checkedTagId)
+            updateTagsOnPost(updatedTags)
+        } else {
+            const copy = [ ...tagsOnPost ]
+            copy.push(checkedTagId)
+            updateTagsOnPost(copy)
+        }
+    }
+
+    return (
+        <article className="manageTagForm">
+
+            <fieldset>
+                <h3 className="is-size-5 has-text-weight-bold mt-3">Add Or Remove Tags</h3>
+                <section className="py-2 px-4">
+                {
+                    tagList.length > 0 &&
+                    tagList.map((tag) => {
+                        return <div key={`tagCheck--${tag.id}`}>
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    value={tag.id}
+                                    checked={tagsOnPost.includes(tag.id)}
+                                    onChange={(e) => addOrRemoveTag(e)}
+                                />
+                                {tag.label}
+                            </label>
+                        </div>
+                    })
+                }
+                </section>
+            </fieldset>
+
+            <button
+                onClick={(clickEvent) => { handleSaveButtonClick(clickEvent) }}
+                className="btn btn-primary"
+            >
+                Submit Changes
+            </button>
+
+            <button onClick={() => updateEditTags(false)}>Cancel</button>
+
+        </article>
+    );
+};

--- a/src/components/posts/PostDetails.js
+++ b/src/components/posts/PostDetails.js
@@ -2,17 +2,23 @@ import { useNavigate, useParams } from "react-router-dom"
 import { getPostById } from "../../managers/posts"
 import { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
+import { getCurrentAuthor } from "../../managers/users"
 
 
 export const PostDetails = ({token}) => {
     const { postId } = useParams()
     const [post, setPost] = useState({})
+    const [currentAuthor, setCurrentAuthor] = useState({})
     const navigate = useNavigate()
 
     useEffect(() => {
         if (postId) {
             getPostById(parseInt(postId)).then(PostDetails => setPost(PostDetails))
         }
+    }, [])
+
+    useEffect(() => {
+        getCurrentAuthor().then(data => setCurrentAuthor(data[0]))
     }, [])
 
 

--- a/src/components/posts/PostDetails.js
+++ b/src/components/posts/PostDetails.js
@@ -3,27 +3,44 @@ import { getPostById } from "../../managers/posts"
 import { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 import { getCurrentAuthor } from "../../managers/users"
+import { ManagePostTags } from "./ManagePostTags"
 
 
 export const PostDetails = ({token}) => {
     const { postId } = useParams()
     const [post, setPost] = useState({})
-    const [currentAuthor, setCurrentAuthor] = useState({})
+    const [postTags, setPostTags] = useState([])
+    const [viewingOwnPost, setViewingOwnPost] = useState(false)
+    const [editTags, updateEditTags] = useState(false)
     const navigate = useNavigate()
 
+    const fetchPostDetails = () => {
+        getPostById(parseInt(postId))
+            .then((postDetails) => {
+                setPost(postDetails)
+                setPostTags(postDetails.tags)
+            })
+    }
+    
     useEffect(() => {
         if (postId) {
-            getPostById(parseInt(postId)).then(PostDetails => setPost(PostDetails))
+            fetchPostDetails()
         }
-    }, [])
+    }, [postId])
 
     useEffect(() => {
-        getCurrentAuthor().then(data => setCurrentAuthor(data[0]))
-    }, [])
+        getCurrentAuthor().then((data) => {
+            const currentAuthor = data[0]
+            if (currentAuthor.id === post?.author?.id) {
+                setViewingOwnPost(true)
+            }
+        })
+    }, [post])
 
 
 
     return (
+        post &&
         <div style={{ margin: "0rem 3rem" }}>
             <h1>{post.title}</h1>
             <article className="postDetails">
@@ -32,6 +49,31 @@ export const PostDetails = ({token}) => {
                 <div>Date: {post.publication_date}</div>
                 <div>Author: <Link to={`/users/${post.author?.id}`}>{post.author?.username}</Link></div>
             </article>
+            <section>
+                {
+                    viewingOwnPost && !editTags &&
+                    <button onClick={() => updateEditTags(true)}>Manage Tags</button>
+                }
+                {
+                    editTags === true
+                            ? <>
+                                <ManagePostTags
+                                    token={token}
+                                    postId={postId}
+                                    currentPost={post}
+                                    originalTagsOnPost={postTags}
+                                    updateEditTags={updateEditTags}
+                                    fetchPostDetails={fetchPostDetails}
+                                />
+                            </>
+                        : <div className="tags">
+                            {
+                                postTags.map((tag) => 
+                                <span className="tag is-primary is-light" key={`posttag--${tag?.label}`}>{tag?.label}</span>)
+                            }
+                        </div>
+                }
+            </section>
             <button onClick={() => { navigate(`/comments/${postId}`) }}>View Comments</button>
             <button onClick={() => { navigate(`/commentform/${postId}`) }}>Add Comment</button>
         </div>

--- a/src/managers/users.js
+++ b/src/managers/users.js
@@ -7,3 +7,15 @@ export const getUserById = (id) => {
     return fetch(`http://localhost:8088/users/${id}`)
         .then(res => res.json())
 }
+
+export const getCurrentAuthor = () => {
+    return fetch(`http://localhost:8088/authors?current=true`, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": `Token ${localStorage.getItem("auth_token")}`
+        }
+    })
+        .then(res => res.json())
+}

--- a/src/managers/users.js
+++ b/src/managers/users.js
@@ -9,7 +9,7 @@ export const getUserById = (id) => {
 }
 
 export const getCurrentAuthor = () => {
-    return fetch(`http://localhost:8088/authors?current=true`, {
+    return fetch(`http://localhost:8000/authors?current=true`, {
         method: "GET",
         headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
## Changes Made

- When a user is on a post details page they should see a list of tags associated with that post
- When a user is viewing the post details page for their own post, they should also see a 'manage tags' button
- When the 'manage tags' button is clicked, the user should see a list of tags to check instead of the normal tag list for viewing
- When a user selects/deselects tags and clicks **submit changes**, the tags associated with that post should be saved, and the user should be automatically viewing the updated post.

## Get My Branch
`git fetch --all`
`git checkout manage-tags-rp`