### PR TITLE
View All Users (If Admin)

### DIFF
--- a/src/Rare.js
+++ b/src/Rare.js
@@ -5,7 +5,7 @@ import { NavBar } from "./components/nav/NavBar"
 
 export const Rare = () => {
   const [token, setTokenState] = useState(localStorage.getItem('auth_token'))
-  const [isRareAdmin, setIsAdminState] = useState(localStorage.getItem('auth_token'))
+  const [isRareAdmin, setIsAdminState] = useState(localStorage.getItem('rare_admin'))
 
   const setToken = (newToken) => {
     localStorage.setItem('auth_token', newToken)
@@ -18,7 +18,7 @@ export const Rare = () => {
   }
 
   return <>
-    <NavBar token={token} setToken={setToken} isAdmin={isRareAdmin} setAdmin={setIsRareAdmin} />
-    <ApplicationViews token={token} setToken={setToken} isAdmin={isRareAdmin} setAdmin={setIsRareAdmin} />
+    <NavBar token={token} setToken={setToken} isAdmin={JSON.parse(isRareAdmin)} setAdmin={setIsRareAdmin} />
+    <ApplicationViews token={token} setToken={setToken} isAdmin={JSON.parse(isRareAdmin)} setAdmin={setIsRareAdmin} />
   </>
 }

--- a/src/Rare.js
+++ b/src/Rare.js
@@ -5,14 +5,20 @@ import { NavBar } from "./components/nav/NavBar"
 
 export const Rare = () => {
   const [token, setTokenState] = useState(localStorage.getItem('auth_token'))
+  const [isRareAdmin, setIsAdminState] = useState(localStorage.getItem('auth_token'))
 
   const setToken = (newToken) => {
     localStorage.setItem('auth_token', newToken)
     setTokenState(newToken)
   }
 
+  const setIsRareAdmin = (isStaff) => {
+    localStorage.setItem('rare_admin', isStaff)
+    setIsAdminState(isStaff)
+  }
+
   return <>
-    <NavBar token={token} setToken={setToken} />
-    <ApplicationViews token={token} setToken={setToken} />
+    <NavBar token={token} setToken={setToken} isAdmin={isRareAdmin} setAdmin={setIsRareAdmin} />
+    <ApplicationViews token={token} setToken={setToken} isAdmin={isRareAdmin} setAdmin={setIsRareAdmin} />
   </>
 }

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { loginUser } from "../../managers/AuthManager"
 
-export const Login = ({ setToken }) => {
+export const Login = ({ setToken, setAdmin }) => {
   const username = useRef()
   const password = useRef()
   const navigate = useNavigate()
@@ -19,6 +19,7 @@ export const Login = ({ setToken }) => {
     loginUser(user).then(res => {
       if ("valid" in res && res.valid) {
         setToken(res.token)
+        setAdmin(res.staff)
         navigate("/")
       }
       else {

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom"
 import { useNavigate } from "react-router-dom"
 import { registerUser } from "../../managers/AuthManager"
 
-export const Register = ({ setToken }) => {
+export const Register = ({ setToken, setAdmin }) => {
   const firstName = useRef()
   const lastName = useRef()
   const email = useRef()
@@ -32,6 +32,7 @@ export const Register = ({ setToken }) => {
         .then(res => {
           if ("valid" in res && res.valid) {
             setToken(res.token)
+            setAdmin(res.staff)
             navigate("/")
           }
         })

--- a/src/components/nav/AdminNav.js
+++ b/src/components/nav/AdminNav.js
@@ -1,0 +1,76 @@
+import { useRef } from "react"
+import { Link, useNavigate } from "react-router-dom"
+import "./NavBar.css"
+import Logo from "./rare.jpeg"
+
+export const AdminNav = ({ token, setToken, isAdmin }) => {
+  const navigate = useNavigate()
+  const navbar = useRef()
+  const hamburger = useRef()
+
+  const showMobileNavbar = () => {
+    hamburger.current.classList.toggle('is-active')
+    navbar.current.classList.toggle('is-active')
+  }
+
+  return (
+    <nav className="navbar is-success mb-3" role="navigation" aria-label="main navigation">
+      <div className="navbar-brand">
+        <a className="navbar-item" href="/">
+          <img src={Logo} height="3rem" alt="Rare Logo" /> <h1 className="title is-4">Rare Publishing</h1>
+        </a>
+
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+        <a role="button" className="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample" onClick={showMobileNavbar} ref={hamburger}>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </a>
+      </div>
+
+      <div className="navbar-menu" ref={navbar}>
+        <div className="navbar-start">
+          {
+            token
+              ?
+              <>
+                <Link to="/posts" className="navbar-item">Posts</Link>
+                <Link to="/my-posts" className="navbar-item">My Posts</Link>
+                <Link to="/categories" className="navbar-item">Category Management</Link>
+                <Link to="/users" className="navbar-item">User Management</Link>
+                <Link to="/tags" className="navbar-item">Tag Management</Link>
+                <Link to="/postform" className="navbar-item">New Post</Link>
+
+
+
+              </>
+              :
+              ""
+          }
+        </div>
+
+        <div className="navbar-end">
+          <div className="navbar-item">
+            <div className="buttons">
+              {
+                token
+                  ?
+                  <button className="button is-outlined" onClick={() => {
+                    setToken('')
+                    localStorage.removeItem('rare_admin')
+                    navigate('/login')
+                  }}>Logout</button>
+                  :
+                  <>
+                    <Link to="/register" className="button is-link">Register</Link>
+                    <Link to="/login" className="button is-outlined">Login</Link>
+
+                  </>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -1,76 +1,14 @@
-import { useRef } from "react"
-import { Link, useNavigate } from "react-router-dom"
-import "./NavBar.css"
-import Logo from "./rare.jpeg"
+import { AdminNav } from "./AdminNav"
+import { UserNav } from "./UserNav"
 
 export const NavBar = ({ token, setToken, isAdmin }) => {
-  const navigate = useNavigate()
-  const navbar = useRef()
-  const hamburger = useRef()
+  
+  let displayNav = <></>
 
-  const showMobileNavbar = () => {
-    hamburger.current.classList.toggle('is-active')
-    navbar.current.classList.toggle('is-active')
+  if (isAdmin) {
+    displayNav = <AdminNav token={token} setToken={setToken} isAdmin={isAdmin} />
+  } else {
+    displayNav = <UserNav token={token} setToken={setToken} isAdmin={isAdmin} />
   }
-
-  return (
-    <nav className="navbar is-success mb-3" role="navigation" aria-label="main navigation">
-      <div className="navbar-brand">
-        <a className="navbar-item" href="/">
-          <img src={Logo} height="3rem" alt="Rare Logo" /> <h1 className="title is-4">Rare Publishing</h1>
-        </a>
-
-        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-        <a role="button" className="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample" onClick={showMobileNavbar} ref={hamburger}>
-          <span aria-hidden="true"></span>
-          <span aria-hidden="true"></span>
-          <span aria-hidden="true"></span>
-        </a>
-      </div>
-
-      <div className="navbar-menu" ref={navbar}>
-        <div className="navbar-start">
-          {
-            token
-              ?
-              <>
-                <Link to="/posts" className="navbar-item">Posts</Link>
-                <Link to="/my-posts" className="navbar-item">My Posts</Link>
-                <Link to="/categories" className="navbar-item">Category Management</Link>
-                <Link to="/users" className="navbar-item">User Management</Link>
-                <Link to="/tags" className="navbar-item">Tag Management</Link>
-                <Link to="/postform" className="navbar-item">New Post</Link>
-
-
-
-              </>
-              :
-              ""
-          }
-        </div>
-
-        <div className="navbar-end">
-          <div className="navbar-item">
-            <div className="buttons">
-              {
-                token
-                  ?
-                  <button className="button is-outlined" onClick={() => {
-                    setToken('')
-                    localStorage.removeItem('rare_admin')
-                    navigate('/login')
-                  }}>Logout</button>
-                  :
-                  <>
-                    <Link to="/register" className="button is-link">Register</Link>
-                    <Link to="/login" className="button is-outlined">Login</Link>
-
-                  </>
-              }
-            </div>
-          </div>
-        </div>
-      </div>
-    </nav>
-  )
+  return displayNav
 }

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -3,7 +3,7 @@ import { Link, useNavigate } from "react-router-dom"
 import "./NavBar.css"
 import Logo from "./rare.jpeg"
 
-export const NavBar = ({ token, setToken }) => {
+export const NavBar = ({ token, setToken, isAdmin }) => {
   const navigate = useNavigate()
   const navbar = useRef()
   const hamburger = useRef()
@@ -57,6 +57,7 @@ export const NavBar = ({ token, setToken }) => {
                   ?
                   <button className="button is-outlined" onClick={() => {
                     setToken('')
+                    localStorage.removeItem('rare_admin')
                     navigate('/login')
                   }}>Logout</button>
                   :

--- a/src/components/nav/UserNav.js
+++ b/src/components/nav/UserNav.js
@@ -1,0 +1,75 @@
+import { useRef } from "react"
+import { Link, useNavigate } from "react-router-dom"
+import "./NavBar.css"
+import Logo from "./rare.jpeg"
+
+export const UserNav = ({ token, setToken, isAdmin }) => {
+  const navigate = useNavigate()
+  const navbar = useRef()
+  const hamburger = useRef()
+
+  const showMobileNavbar = () => {
+    hamburger.current.classList.toggle('is-active')
+    navbar.current.classList.toggle('is-active')
+  }
+
+  return (
+    <nav className="navbar is-success mb-3" role="navigation" aria-label="main navigation">
+      <div className="navbar-brand">
+        <a className="navbar-item" href="/">
+          <img src={Logo} height="3rem" alt="Rare Logo" /> <h1 className="title is-4">Rare Publishing</h1>
+        </a>
+
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+        <a role="button" className="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample" onClick={showMobileNavbar} ref={hamburger}>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </a>
+      </div>
+
+      <div className="navbar-menu" ref={navbar}>
+        <div className="navbar-start">
+          {
+            token
+              ?
+              <>
+                <Link to="/posts" className="navbar-item">Posts</Link>
+                <Link to="/my-posts" className="navbar-item">My Posts</Link>
+                <Link to="/categories" className="navbar-item">Category Management</Link>
+                <Link to="/tags" className="navbar-item">Tag Management</Link>
+                <Link to="/postform" className="navbar-item">New Post</Link>
+
+
+
+              </>
+              :
+              ""
+          }
+        </div>
+
+        <div className="navbar-end">
+          <div className="navbar-item">
+            <div className="buttons">
+              {
+                token
+                  ?
+                  <button className="button is-outlined" onClick={() => {
+                    setToken('')
+                    localStorage.removeItem('rare_admin')
+                    navigate('/login')
+                  }}>Logout</button>
+                  :
+                  <>
+                    <Link to="/register" className="button is-link">Register</Link>
+                    <Link to="/login" className="button is-outlined">Login</Link>
+
+                  </>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/users/UserList.js
+++ b/src/components/users/UserList.js
@@ -1,28 +1,28 @@
 import { Link } from "react-router-dom";
-import { getUsers } from "../../managers/users"
+import { getAllAuthors } from "../../managers/users"
 import { useEffect, useState } from 'react';
 
 export const UserList = () => {
   const [users, setUsers] = useState([]);
 
   useEffect(() => {
-    getUsers().then(userArray => setUsers(userArray));
+    getAllAuthors().then(userArray => setUsers(userArray));
   }, []);
 
   return (
 
     <>
-      <h2 className="userList">List of Users</h2>
+      <h2 className="userList py-1 ml-3">List of Users</h2>
 
-      <article className="users">
+      <article className="users pt-1 pb-5">
         {users
           .sort((a, b) => a.username.localeCompare(b.username))
           .map((user) => (
-            <section className="user" key={user.id}>
-              <div>================================================</div>
-              <div className="userName">Username: {user.username}</div>
+            <section className="box mx-6 mt-3 user" key={user.id}>
+              <div className="userName title is-6">{user.username}</div>
               <div className="userfullName">Full Name: <Link to={`/users/${user.id}`}>{user.first_name} {user.last_name}</Link></div>
               <div className="userEmail">Email: {user.email} </div>
+              <div className="userType">User Type: {user.is_staff ? "Admin" : "Author"} </div>
             </section>
           ))}
       </article>

--- a/src/managers/users.js
+++ b/src/managers/users.js
@@ -1,5 +1,12 @@
-export const getUsers = () => {
-    return fetch("http://localhost:8000/users")
+export const getAllAuthors = () => {
+    return fetch(`http://localhost:8000/authors`, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": `Token ${localStorage.getItem("auth_token")}`
+        }
+    })
         .then(res => res.json())
 }
 

--- a/src/views/AdminViews.js
+++ b/src/views/AdminViews.js
@@ -1,0 +1,45 @@
+import { Route, Routes } from "react-router-dom"
+import { Login } from "../components/auth/Login"
+import { Register } from "../components/auth/Register"
+import { TagList } from '../components/tag/TagList'
+import { Authorized } from "./Authorized"
+import { PostList } from "../components/posts/PostList"
+import { UserPost } from "../components/posts/UserPost"
+import { PostDetails } from "../components/posts/PostDetails"
+import { CategoryList } from "../components/Categories/CategoryList"
+import { UserList } from "../components/users/UserList"
+import { PostForm } from "../components/posts/PostForm"
+import { PostEdit } from "../components/posts/PostEdit"
+import { UserDetail } from "../components/users/UserDetail"
+import { PostComments } from "../components/comments/PostComments"
+import { CommentForm } from "../components/comments/CommentForm"
+import { SubscribedUserPosts } from "../components/subscriptions/ViewSubscribedUserPosts"
+
+export const AdminViews = ({ token, setToken, isAdmin, setAdmin}) => {
+  return <>
+    <Routes>
+      <Route path="/login" element={<Login setToken={setToken} setAdmin={setAdmin} />}  />
+      <Route path="/register" element={<Register setToken={setToken} setAdmin={setAdmin} />}  />
+      <Route element={<Authorized token={token} />}>
+        <Route index element={<SubscribedUserPosts token={token} />} />
+
+        <Route path="/tags" element={<TagList token={token} />}  />
+        <Route path="/posts" element={<PostList />}  />
+        <Route path="/my-posts" element={<UserPost token={token}/>}  />
+        <Route path="/posts/:postId" element={<PostDetails token={token}/>}  />
+        <Route path="/categories" element={<CategoryList />}  />
+        <Route path="/comments/:postId" element={<PostComments token={token}/>}  />
+        <Route path="/commentform/:postId" element={<CommentForm token={token}/>}  />
+        
+        <Route path="/users"> 
+          <Route index element={<UserList />} />
+          <Route path=":userId" element={<UserDetail token={token}/>} />
+        </Route>
+        <Route path="/postform" element={<PostForm token={token}/>}  />
+        <Route path="/my-posts/:postId/edit" element={<PostEdit />}  />
+ 
+
+      </Route>
+    </Routes>
+  </>
+}

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -1,46 +1,20 @@
-import { Route, Routes } from "react-router-dom"
-import { Login } from "../components/auth/Login"
-import { Register } from "../components/auth/Register"
-import { TagList } from '../components/tag/TagList'
-import { Authorized } from "./Authorized"
-import { PostList } from "../components/posts/PostList"
-import { UserPost } from "../components/posts/UserPost"
-import { PostDetails } from "../components/posts/PostDetails"
-import { CategoryList } from "../components/Categories/CategoryList"
-import { UserList } from "../components/users/UserList"
-import { PostForm } from "../components/posts/PostForm"
-import { PostEdit } from "../components/posts/PostEdit"
-import { UserDetail } from "../components/users/UserDetail"
-import { PostComments } from "../components/comments/PostComments"
-import { CommentForm } from "../components/comments/CommentForm"
-import { SubscribedUserPosts } from "../components/subscriptions/ViewSubscribedUserPosts"
-import { EditCategory } from "../components/Categories/EditCategory"
+import { AdminViews } from "./AdminViews"
+import { UserViews } from "./UserViews"
 
 export const ApplicationViews = ({ token, setToken, isAdmin, setAdmin}) => {
-  return <>
-    <Routes>
-      <Route path="/login" element={<Login setToken={setToken} setAdmin={setAdmin} />}  />
-      <Route path="/register" element={<Register setToken={setToken} setAdmin={setAdmin} />}  />
-      <Route element={<Authorized token={token} />}>
-        <Route index element={<SubscribedUserPosts token={token} />} />
 
-        <Route path="/tags" element={<TagList token={token} />}  />
-        <Route path="/posts" element={<PostList />}  />
-        <Route path="/my-posts" element={<UserPost token={token}/>}  />
-        <Route path="/posts/:postId" element={<PostDetails token={token}/>}  />
-        <Route path="/categories" element={<CategoryList />}  />
-        <Route path="/comments/:postId" element={<PostComments token={token}/>}  />
-        <Route path="/commentform/:postId" element={<CommentForm token={token}/>}  />
-        
-        <Route path="/users"> 
-          <Route index element={<UserList />} />
-          <Route path=":userId" element={<UserDetail token={token}/>} />
-        </Route>
-        <Route path="/postform" element={<PostForm token={token}/>}  />
-        <Route path="/my-posts/:postId/edit" element={<PostEdit />}  />
- 
+  if (isAdmin) {
+    return <AdminViews 
+    token={token} 
+    setToken={setToken} 
+    isAdmin={isAdmin} 
+    setAdmin={setAdmin} />
 
-      </Route>
-    </Routes>
-  </>
+  } else {
+    return <UserViews 
+    token={token} 
+    setToken={setToken} 
+    isAdmin={isAdmin} 
+    setAdmin={setAdmin}/>
+  }
 }

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -16,11 +16,11 @@ import { CommentForm } from "../components/comments/CommentForm"
 import { SubscribedUserPosts } from "../components/subscriptions/ViewSubscribedUserPosts"
 import { EditCategory } from "../components/Categories/EditCategory"
 
-export const ApplicationViews = ({ token, setToken}) => {
+export const ApplicationViews = ({ token, setToken, isAdmin, setAdmin}) => {
   return <>
     <Routes>
-      <Route path="/login" element={<Login setToken={setToken} />}  />
-      <Route path="/register" element={<Register setToken={setToken} />}  />
+      <Route path="/login" element={<Login setToken={setToken} setAdmin={setAdmin} />}  />
+      <Route path="/register" element={<Register setToken={setToken} setAdmin={setAdmin} />}  />
       <Route element={<Authorized token={token} />}>
         <Route index element={<SubscribedUserPosts token={token} />} />
 

--- a/src/views/UserViews.js
+++ b/src/views/UserViews.js
@@ -1,0 +1,44 @@
+import { Route, Routes } from "react-router-dom"
+import { Login } from "../components/auth/Login"
+import { Register } from "../components/auth/Register"
+import { TagList } from '../components/tag/TagList'
+import { Authorized } from "./Authorized"
+import { PostList } from "../components/posts/PostList"
+import { UserPost } from "../components/posts/UserPost"
+import { PostDetails } from "../components/posts/PostDetails"
+import { CategoryList } from "../components/Categories/CategoryList"
+import { UserList } from "../components/users/UserList"
+import { PostForm } from "../components/posts/PostForm"
+import { PostEdit } from "../components/posts/PostEdit"
+import { UserDetail } from "../components/users/UserDetail"
+import { PostComments } from "../components/comments/PostComments"
+import { CommentForm } from "../components/comments/CommentForm"
+import { SubscribedUserPosts } from "../components/subscriptions/ViewSubscribedUserPosts"
+
+export const UserViews = ({ token, setToken, isAdmin, setAdmin}) => {
+  return <>
+    <Routes>
+      <Route path="/login" element={<Login setToken={setToken} setAdmin={setAdmin} />}  />
+      <Route path="/register" element={<Register setToken={setToken} setAdmin={setAdmin} />}  />
+      <Route element={<Authorized token={token} />}>
+        <Route index element={<SubscribedUserPosts token={token} />} />
+
+        <Route path="/tags" element={<TagList token={token} />}  />
+        <Route path="/posts" element={<PostList />}  />
+        <Route path="/my-posts" element={<UserPost token={token}/>}  />
+        <Route path="/posts/:postId" element={<PostDetails token={token}/>}  />
+        <Route path="/categories" element={<CategoryList />}  />
+        <Route path="/comments/:postId" element={<PostComments token={token}/>}  />
+        <Route path="/commentform/:postId" element={<CommentForm token={token}/>}  />
+        
+        
+        <Route path="/users/:userId" element={<UserDetail token={token}/>} />
+        
+        <Route path="/postform" element={<PostForm token={token}/>}  />
+        <Route path="/my-posts/:postId/edit" element={<PostEdit />}  />
+ 
+
+      </Route>
+    </Routes>
+  </>
+}


### PR DESCRIPTION
## Changes Made

- Separated Admin and User views and permissions. Application Views now splits into admin and user views. Navbar now splits into admin and user nav.
- Stored isAdmin state in localStorage after retrieving from authentication response. _Note: Must use JSON.parse() for the retrieved boolean to be useable. The isAdmin variable passed down as a prop has already been parsed_
- When a user logs out, the isAdmin state is removed from localStorage
- Displayed all users in a list when logged in as an admin. If logged in as a user, the 'user management' tab will not appear, and the url '/users' will lead to a blank page.

## Get My Branch
`git fetch --all`
`git checkout view-all-users`